### PR TITLE
Fix user template path

### DIFF
--- a/app.py
+++ b/app.py
@@ -178,7 +178,7 @@ def user_list():
         return "คุณไม่มีสิทธิ์เข้าถึงหน้านี้", 403
     users = session_db.query(User).order_by(User.created_at.desc()).all()
     session_db.close()
-    return render_template("users.html", users=users, is_admin=True)
+    return render_template("user.html", users=users, is_admin=True)
 
 @app.route('/register', methods=['GET', 'POST'])
 def register():


### PR DESCRIPTION
## Summary
- fix route to render `user.html` instead of `users.html`

## Testing
- `python3 - <<'PY'
try:
    import flask
    print('Flask available')
except Exception as e:
    print('Import error:', e)
PY` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686fc58e7d9483269b87c9dd87a43323