### PR TITLE
Add MIME type validation for uploads

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ opencv-python
 pytesseract
 pdf2image
 Pillow
+python-magic


### PR DESCRIPTION
## Summary
- verify uploaded file MIME type with `python-magic`
- add allowed MIME type list
- document python-magic in requirements

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686fdc6864248326a57d9dc360ee2e40