### PR TITLE
Add isolation forest and autoencoder risk scoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,8 @@ database.db
 
 # Uploaded files
 uploads/
+models/*.pkl
+models/*.h5
 
 # OS generated files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Money Guardian is a Flask application that extracts information from bank slip i
 ```bash
 pip install -r requirements.txt
 ```
+   The list includes `scikit-learn` and `tensorflow` which are required for the risk models.
 
 3. Install the OCR system packages (`tesseract-ocr` and `poppler-utils`).
 
@@ -55,6 +56,10 @@ Ensure the `tesseract` executable is in your `PATH`. On some systems you may nee
 
 Uploaded slip images are stored in the `uploads/` directory. The dashboard displays transactions extracted from these files.
 Only image files (`.png`, `.jpg`, `.jpeg`) or PDF documents can be uploaded and files larger than the configured limit will be rejected.
+
+## Risk Scoring Models
+
+Risk calculation combines an Isolation Forest and an Autoencoder model. Place trained model files in the `models/` directory as `isolation_forest.pkl` and `autoencoder.h5`. The application will fall back to a default score if the models or required machine learning libraries are unavailable.
 
 ## Configuration
 

--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 ### app.py (Production-ready Enhancements with CSRF)
 
 from flask import Flask, render_template, request, redirect, url_for, session, send_from_directory
-import os, random, re
+import os, re
 import cv2
 import pytesseract
 import magic
@@ -13,6 +13,7 @@ from datetime import datetime
 from pdf2image import convert_from_path
 from werkzeug.security import generate_password_hash, check_password_hash
 from flask_wtf import CSRFProtect  # ✅ เพิ่ม CSRF protection
+from risk_model import calculate_risk
 
 # === CONFIG ===
 UPLOAD_FOLDER = os.getenv('UPLOAD_FOLDER', 'uploads')
@@ -150,7 +151,7 @@ def index():
             file.save(filepath)
 
             data = process_slip_with_tesseract(filepath)
-            dummy_risk_score = round(random.uniform(0.1, 0.99), 2)
+            risk_score = calculate_risk(data)
             user_id = session.get("user_id")
 
             try:
@@ -166,7 +167,7 @@ def index():
                 amount=amount_val,
                 date_str=data.get("date"),
                 raw_text=data.get("raw_text"),
-                risk_score=dummy_risk_score,
+                risk_score=risk_score,
                 filename=unique_filename
             )
             session_db.add(tx)
@@ -175,7 +176,7 @@ def index():
 
             result = {
                 'filename': unique_filename,
-                'risk_score': dummy_risk_score,
+                'risk_score': risk_score,
                 'amount': data.get('amount'),
                 'date': data.get('date'),
                 'time': data.get('time'),

--- a/models/README.md
+++ b/models/README.md
@@ -1,0 +1,2 @@
+Trained machine learning models should be placed here as `isolation_forest.pkl` and `autoencoder.h5`.
+These files are ignored by git.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,7 @@ pytesseract
 pdf2image
 Pillow
 python-magic
+numpy
+scikit-learn
+joblib
+tensorflow

--- a/risk_model.py
+++ b/risk_model.py
@@ -1,0 +1,59 @@
+import os
+import numpy as np
+
+try:
+    import joblib
+    from sklearn.ensemble import IsolationForest
+    from tensorflow.keras.models import load_model
+except Exception:  # modules might not be installed in some environments
+    joblib = None
+    load_model = None
+
+MODEL_DIR = os.getenv('MODEL_DIR', 'models')
+IFOREST_PATH = os.path.join(MODEL_DIR, 'isolation_forest.pkl')
+AUTOENCODER_PATH = os.path.join(MODEL_DIR, 'autoencoder.h5')
+
+
+def load_models():
+    """Load Isolation Forest and Autoencoder models if available."""
+    if joblib is None or load_model is None:
+        return None, None
+    if not (os.path.exists(IFOREST_PATH) and os.path.exists(AUTOENCODER_PATH)):
+        return None, None
+    iforest = joblib.load(IFOREST_PATH)
+    autoenc = load_model(AUTOENCODER_PATH)
+    return iforest, autoenc
+
+
+def _extract_features(data: dict):
+    """Extract simple numerical features from OCR data."""
+    try:
+        amount = float(data.get('amount', '0').replace(',', ''))
+    except Exception:
+        amount = 0.0
+    sender_len = len(data.get('sender_name') or '')
+    receiver_len = len(data.get('receiver_name') or '')
+    return [amount, sender_len, receiver_len]
+
+
+def calculate_risk(data: dict) -> float:
+    """Calculate risk score using Isolation Forest and Autoencoder models."""
+    features = _extract_features(data)
+    iforest, autoenc = load_models()
+    feats = np.array(features).reshape(1, -1)
+
+    if iforest is not None:
+        iso_score = -iforest.decision_function(feats)[0]
+        iso_score = (iso_score + 1) / 2
+    else:
+        iso_score = 0.5
+
+    if autoenc is not None:
+        recon = autoenc.predict(feats, verbose=0)
+        mse = np.mean(np.square(feats - recon))
+        auto_score = mse / (mse + 1)
+    else:
+        auto_score = 0.5
+
+    risk = (iso_score + auto_score) / 2
+    return round(float(risk), 2)


### PR DESCRIPTION
## Summary
- implement `risk_model` with isolation forest and autoencoder logic
- compute risk scores using the new models in `app.py`
- document machine learning dependencies and risk models in the README
- ignore model files via `.gitignore`
- add placeholder for model directory

## Testing
- `python -m py_compile app.py risk_model.py`

------
https://chatgpt.com/codex/tasks/task_e_686fde1e9bac832683ea183003a4e1bf