### PR TITLE
Add environment variable for tesseract path

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pip install -r requirements.txt
     brew install poppler
     ```
 
-Ensure the `tesseract` executable is in your `PATH`. On some systems you may need to specify the path in `pytesseract.pytesseract.tesseract_cmd`.
+Ensure the `tesseract` executable is in your `PATH`. Alternatively set `TESSERACT_CMD` to the full executable path and the application will use it automatically.
 If these packages are missing the upload page will display an error about missing OCR dependencies.
 
 ## Running the Application

--- a/app.py
+++ b/app.py
@@ -7,6 +7,11 @@ import io
 import cv2
 import pytesseract
 import magic
+
+# Configure tesseract executable path from environment
+TESSERACT_CMD = os.getenv('TESSERACT_CMD')
+if TESSERACT_CMD:
+    pytesseract.pytesseract.tesseract_cmd = TESSERACT_CMD
 from uuid import uuid4
 from werkzeug.utils import secure_filename
 from sqlalchemy import Column, Integer, String, Float, DateTime, Boolean, ForeignKey, create_engine


### PR DESCRIPTION
## Summary
- allow configuring the path to the `tesseract` executable via `TESSERACT_CMD`
- document `TESSERACT_CMD` in the README

## Testing
- `python -m py_compile app.py risk_model.py`
- `pip install pyflakes` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68712d360bdc8326b15fe3cff000abc1